### PR TITLE
Input pattern fix

### DIFF
--- a/app/src/components/registration/input.js
+++ b/app/src/components/registration/input.js
@@ -39,7 +39,7 @@ class Input extends Component {
       <form onSubmit={evt => this.submit(evt)}>
         <input
           type="text"
-          pattern="[A-Za-z0-9]+"
+          pattern="^[\w.@+-]+$"
           placeholder={ this.props.placeholder }
           autoComplete={false}
           ref={a => this.setRef(a)}


### PR DESCRIPTION
Fixed input pattern to support all usernames that django supports.
Previously usernames containing special characters like `@` and `_` would yield a html validation error due to the pattern only allowing characters from a-Z and 0-9 