### PR TITLE
Made getAttendees load more than 10

### DIFF
--- a/app/src/services/attendee/attendee.service.js
+++ b/app/src/services/attendee/attendee.service.js
@@ -124,10 +124,10 @@ class AttendeeServiceProvider {
    * @param {Number} page - what page to start fetching from 
    * @returns {Observable<Array<Attendee>>} - an observable that resolves into a list of Attendees
    */ 
-  getAttendees(event, page = 1) {
+  getAttendees(event, page = 1, page_size = 30) {
     const count = 0;
     
-    return http.get(`${API_BASE}${API_ATTENDEES}`, { event: event.id, page })
+    return http.get(`${API_BASE}${API_ATTENDEES}`, { event: event.id, page, page_size })
       .map((result) => {
         let attendees = result.results;
         const a = [];


### PR DESCRIPTION
Regme now loads 30 attendees at a time instead of just 10.