### PR TITLE
Read response data based on new attendance API

### DIFF
--- a/app/src/components/registration/index.js
+++ b/app/src/components/registration/index.js
@@ -123,22 +123,22 @@ class Registration extends Component {
   }
 
   handleAttendeeResponse(stream) {
-    stream.subscribe((v) => {
+    stream.subscribe(({ detail }) => {
       // this.event.refresh();
-      this.attendeeService.getCached(v.attendee).register();
-      this.updateStatus(new Status('OK', v.message));
+      this.attendeeService.getCached(detail.attendee).register();
+      this.updateStatus(new Status('OK', detail.message));
       this.setState(Object.assign({}, this.state, {
-        attend_status: v,
+        attend_status: detail,
         placeholder: 'default',
         ivalue: '',
       }));
-    }, (v) => {
-      this.updateStatus(new Status('ERROR', v.message));
-      const attendeeStatus = v;
+    }, ({ detail }) => {
+      this.updateStatus(new Status('ERROR', detail.message));
+      const attendeeStatus = detail;
       let placeholder = 'default';
       const ivalue = '';
       let showModal = false;
-      switch (v.attend_status) {
+      switch (detail.attend_status) {
 
         case 51:
         case 50:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ var env = {
   'RG_API_EVENTS': 'events/',
   'RG_API_AUTH': 'auth/',
   'RG_API_ATTENDEES': 'attendees/',
-  'RG_API_ATTEND': 'attend/',
+  'RG_API_ATTEND': 'attendees/register_attendance/',
   'RG_API_USERS': 'users/',
   'RG_OIDC_CLIENT_ID': '',
   'RG_OIDC_AUTHORITY': 'http://localhost:8000/openid/',


### PR DESCRIPTION
Based on new attendance API, found here: https://github.com/dotkom/onlineweb4/pull/2349

The response is now wrapped in an object with a `detail` key, and the URL is changed to use DRF actions.